### PR TITLE
Add feature to be abble to uninstalled plugins. Especially xsquash4jira.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ The default database is h2.
     squash_maxpermsize: '128m'
     squash_extra_java_args: '-javaagent:path/to/glowroot.jar'
 
+### Plugins
+
+By default Squash-tm is installed with a **xsquash4jira** plugin which try to synchronize every 5 minutes. Most of the time, it is unecessary, so this role uninstall it.
+
+    squash_plugins2remove:
+      - xsquash4jira
+
 ### Others
 
     squash_http_port: '8080'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,9 @@ squash_packages:
 - dbconfig-common
 - squash-tm
 
+squash_plugins2remove:
+- xsquash4jira
+
 squash_xmx: '512m'
 
 squash_http_port: '8080'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,9 @@
     dest: "/etc/default/squash-tm"
   notify: restart squash-tm
 
+- name: Ensure plugins are uninstalled.
+  include_tasks: "plugins.yml"
+
 - name: Ensure database is ready.
   include_tasks: "{{ squash_db_type }}.yml"
 

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,0 +1,14 @@
+---
+- name: Find plugins to remove.
+  find:
+    paths: '/usr/share/squash-tm/plugins'
+    patterns: "*{{ item }}*"
+  loop: "{{ squash_plugins2remove }}"
+  register: plugins2remove
+
+- name: Ensure undesired plugins are absent.
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ plugins2remove.results | map(attribute='files') | flatten }}"
+  notify: restart squash-tm


### PR DESCRIPTION
Because it is not a good thing to have this kind of recurring logs.

```
[19-05-29 16:39:30.158] SquashTM - 27321  INFO [squashtest.tm.service.ThreadPoolTaskScheduler-1] [] --- org.squashtest.tm.plugin.jirasync.service.RequirementSynchronizationService: [JIRA-SYNC] - Begin Synchronisation with JIRA.
[19-05-29 16:59:30.750] SquashTM - 27321  INFO [squashtest.tm.service.ThreadPoolTaskScheduler-2] [] --- org.squashtest.tm.plugin.jirasync.service.JiraReportingService: [JIRA-SYNC] - Begin reporting to JIRA.
[19-05-29 16:59:30.838] SquashTM - 27321  INFO [squashtest.tm.service.ThreadPoolTaskScheduler-2] [] --- org.squashtest.tm.plugin.jirasync.service.JiraReportingService: [JIRA-SYNC] - Finished reporting to JIRA.
[19-05-29 17:04:30.839] SquashTM - 27321  INFO [squashtest.tm.service.ThreadPoolTaskScheduler-4] [] --- org.squashtest.tm.plugin.jirasync.service.RequirementSynchronizationService: [JIRA-SYNC] - Begin Synchronisation with JIRA.
```